### PR TITLE
Экстрактор ссылок

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,10 @@ let package = Package(
         .library(
             name: "YamlParser",
             targets: ["YamlParser"]
+        ),
+        .library(
+            name: "ReferenceExtractor",
+            targets: ["ReferenceExtractor"]
         )
     ],
     dependencies: [
@@ -33,6 +37,12 @@ let package = Package(
                 "YamlParser",
                 "XcodeProj",
                 "Rainbow",
+                "Yams"
+            ]
+        ),
+        .target(
+            name: "ReferenceExtractor",
+            dependencies: [
                 "Yams"
             ]
         ),
@@ -60,6 +70,10 @@ let package = Package(
         .testTarget(
             name: "EndToEndTests",
             dependencies: ["YamlParser", "SurfGenKit"]
+        ),
+        .testTarget(
+            name: "RefereceExtractorTests",
+            dependencies: ["ReferenceExtractor"]
         )
     ]
 )

--- a/Sources/ReferenceExtractor/CustomError.swift
+++ b/Sources/ReferenceExtractor/CustomError.swift
@@ -1,0 +1,37 @@
+//
+//  CustomError.swift
+//
+//
+//  Created by Александр Кравченков on 12.12.2020.
+//
+
+import Foundation
+
+public struct CustomError: LocalizedError {
+    var message: String
+    var line: Int
+    var function: String
+    var column: Int
+
+    public init(message: String, line: Int = #line, function: String = #function, column: Int = #column) {
+        self.message = message
+        self.line = line
+        self.function = function
+        self.column = column
+    }
+
+    public var errorDescription: String? {
+        var msg = "❌ Error!"
+        msg += "\n"
+        msg += "Message: \(self.message)"
+        msg += "\n"
+        msg += "Debug info:"
+        msg += "\n\t"
+        msg += "function: \(self.function)"
+        msg += "\n\t"
+        msg += "line: \(self.line)"
+        msg += "\n\t"
+        msg += "Column: \(self.column)"
+        return msg
+    }
+}

--- a/Sources/ReferenceExtractor/FileProvider.swift
+++ b/Sources/ReferenceExtractor/FileProvider.swift
@@ -1,0 +1,24 @@
+//
+//  FileProvider.swift
+//
+//
+//  Created by Александр Кравченков on 12.12.2020.
+//
+
+import Foundation
+
+/// Interface for object which can deal with files in file system
+public protocol FileProvider {
+    func isReadableFile(at path: String) -> Bool
+    func readFile(at path: String) throws -> Data?
+}
+
+extension FileManager: FileProvider {
+    public func readFile(at path: String) -> Data? {
+        return self.contents(atPath: path)
+    }
+
+    public func isReadableFile(at path: String) -> Bool {
+        return self.isReadableFile(atPath: path)
+    }
+}

--- a/Sources/ReferenceExtractor/ReferenceExtractor.swift
+++ b/Sources/ReferenceExtractor/ReferenceExtractor.swift
@@ -26,9 +26,7 @@ import Yams
 /// If you want to working in parallel, you should create different instances of this class
 ///
 /// **NOTICE**
-/// Doesn't process array.
-/// It means that if there is a `$ref` inside array (on any depth) it won't proccess (and even read) it
-/// So it means that reference like that won't be extracted
+/// May be tricky with refs which were inserted in an array
 public class ReferenceExtractor {
     let rootSpecPath: URL
     let fileProvider: FileProvider
@@ -86,6 +84,8 @@ extension ReferenceExtractor {
 
         for (key, value) in spec {
             switch value {
+            case let arr as [[String: Any]]:
+                try arr.forEach { try collectAllRefs(in: $0, file: file) }
             case let sp as [String: Any]:
                 try self.collectAllRefs(in: sp, file: file)
             case let str as String:

--- a/Sources/ReferenceExtractor/ReferenceExtractor.swift
+++ b/Sources/ReferenceExtractor/ReferenceExtractor.swift
@@ -1,0 +1,153 @@
+//
+//  ReferenceExecutor.swift
+//
+//
+//  Created by Александр Кравченков on 12.12.2020.
+//
+
+import Foundation
+import Yams
+
+/// This class extracts all references (`$ref` tag) from specific OpenAPI specification file recursively
+///
+/// For example:
+/// We have file at path`../api/billings/api.yaml`
+/// Inside this file we have some REST methods which contain references on some models in another spec files.
+///
+/// `ReferenceExtractor` will extract referenced files' pathes
+/// And also it will read each file and will make the same extraction
+/// And it will repeat it until it read all dependencies
+///
+/// `ReferenceExtractor` is proof to reference cycles
+///
+///
+/// **WARNING**
+/// Isn't thread-safe!
+/// If you want to working in parallel, you should create different instances of this class
+///
+/// **NOTICE**
+/// Doesn't process array.
+/// It means that if there is a `$ref` inside array (on any depth) it won't proccess (and even read) it
+/// So it means that reference like that won't be extracted
+public class ReferenceExtractor {
+    let rootSpecPath: URL
+    let fileProvider: FileProvider
+
+    // this field will be fulfilled by extract process
+    var readStack: [String]
+
+    /// Initializer
+    ///
+    /// - Parameters:
+    ///     - pathToSpec: Path to YAML specification from which yupu need to extract references
+    ///     - fileProvider: Will be used for reading strings in utf8 encoding
+    /// - Throws:
+    ///    - CustomError: In case when file at `pathToSpec` isn't readable
+    public init(pathToSpec: URL, fileProvider: FileProvider) throws {
+        self.rootSpecPath = pathToSpec
+        self.fileProvider = fileProvider
+        guard fileProvider.isReadableFile(at: pathToSpec.absoluteString) else {
+            throw CustomError(message: "file at path \(pathToSpec) isn't readable")
+        }
+        self.readStack = [pathToSpec.absoluteString]
+    }
+}
+
+extension ReferenceExtractor {
+
+    public func extract() throws -> [String] {
+        let spec = try self.loadSpec(path: self.rootSpecPath.absoluteString)
+        try collectAllRefs(in: spec, file: self.rootSpecPath.absoluteString)
+        var copy = self.readStack
+        copy.removeAll(where: { $0 == self.rootSpecPath.absoluteString })
+        return copy
+    }
+
+    func loadSpec(path: String) throws -> [String: Any] {
+        guard let content = try self.fileProvider.readFile(at: path) else {
+            throw CustomError(message: "file at path \(path) can't be readed. We read and got 0 bytes")
+        }
+
+        guard let str = String(data: content, encoding: .utf8) else {
+            throw CustomError(message: "file at path \(path) perhaps isn't a text or it is in wrong encoding. We couldn't convert it in an utf8 string")
+        }
+
+        guard
+            let parsed = try Yams.load(yaml: str),
+            let spec = parsed as? [String: Any]
+        else {
+            throw CustomError(message: "Something went wrong with file at path \(path). Wa had parsed it, but we couldn't transform YAML to dictionary")
+        }
+
+        return spec
+    }
+
+    func collectAllRefs(in spec: [String: Any], file: String) throws {
+
+        for (key, value) in spec {
+            switch value {
+            case let sp as [String: Any]:
+                try self.collectAllRefs(in: sp, file: file)
+            case let str as String:
+                guard key == "$ref" else {
+                    continue
+                }
+                let splited = str.splitOnFilePathAndYamlPath()
+                // if file path is empty then we must skip it because it is reference to local (for current file) entity
+                // or it's just a broken ref
+                guard !splited.filePath.isEmpty else {
+                    continue
+                }
+                try readOther(filePath: splited.filePath, fromFile: file)
+            default:
+                continue
+            }
+        }
+    }
+
+
+    func readOther(filePath: String, fromFile: String) throws {
+        var rootUrl = self.rootSpecPath
+
+        rootUrl.deleteLastPathComponent()
+
+        let resultedUrlToFileToParse = rootUrl.absoluteString.appending(filePath)
+
+        // if we already read this file we won't read it again
+        if self.readStack.contains(resultedUrlToFileToParse) {
+            return
+        }
+
+        // mark it as readed and continue parsing
+        // it's a protection against "genius" who make reference to `file A` from `file A`
+        //
+        // for example in file `models.yaml` sometimes you can see: `$ref:"models.yaml#/..."`
+        // and it's a protection just from this
+        //
+        // the idea is:
+        // if we have read this file
+        // then we shouldn't read it again because we would execute all refs eventually
+        // and we don't need to read in twice
+        self.readStack.append(resultedUrlToFileToParse)
+
+        let res = try self.loadSpec(path: resultedUrlToFileToParse)
+
+        return try collectAllRefs(in: res, file: filePath)
+    }
+}
+
+extension String {
+    /// Splits ../common/errors.yaml#/components/schemas/ApiErrorResponse on
+    /// ../common/errors.yaml
+    /// and
+    /// /components/schemas/ApiErrorResponse
+    func splitOnFilePathAndYamlPath() -> (filePath: String, yamlPath: String) {
+        let spl = self.split(separator: "#")
+
+        guard spl.count == 2 else {
+            return ("", "")
+        }
+
+        return (String(spl[0]), String(spl[1]))
+    }
+}

--- a/Tests/RefereceExtractorTests/ErrorThrowingTests.swift
+++ b/Tests/RefereceExtractorTests/ErrorThrowingTests.swift
@@ -1,0 +1,90 @@
+//
+//  Tests.swift
+//  
+//
+//  Created by Александр Кравченков on 12.12.2020.
+//
+
+@testable import ReferenceExtractor
+import XCTest
+
+/// Cases:
+///
+/// - Error will be thrown for unreadble file in init
+/// - Error wont be thrown for readable file in init
+///
+/// - Error will be thrown for unreadble file in $ref
+/// - Error won't be thrown for readble file in $ref
+/// - Error will be thrown for wrong encoded file (not utf8)
+class ErrorThrowingTests: XCTestCase {
+
+    func testErrorWillBeThrownForUnreadbleFileInInit() {
+        // Arrange
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = false
+
+        // Act - Assert
+        XCTAssertThrowsError(try ReferenceExtractor(pathToSpec: URL(string: "/file/path")!, fileProvider: fileProvider))
+    }
+
+    func testErrorWontBeThrownForReadableFileInInit() {
+        // Arrange
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = true
+
+        // Act - Assert
+        XCTAssertNoThrow(try ReferenceExtractor(pathToSpec: URL(string: "/file/path")!, fileProvider: fileProvider))
+    }
+
+    func testErrorWillBeThrownForUnreadbleFileInRef() throws {
+        // Arrange
+
+        let rootPath = "/file/path"
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = true
+        fileProvider.files[rootPath] = SpecFilesDeclaration.withOneFileRef
+
+        let extrator = try ReferenceExtractor(pathToSpec: URL(string: rootPath)!, fileProvider: fileProvider)
+
+        // Act
+
+        XCTAssertThrowsError(try extrator.extract())
+    }
+
+    func testErrorWontBeThrownForReadbleFileInRef() throws {
+        // Arrange
+
+        let rootPath = "/file/path"
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = true
+        fileProvider.files[rootPath] = SpecFilesDeclaration.withOneFileRef
+        fileProvider.files["/file/models.yaml"] = SpecFilesDeclaration.withoutRefs
+
+        let extrator = try ReferenceExtractor(pathToSpec: URL(string: rootPath)!, fileProvider: fileProvider)
+
+        // Act
+
+        XCTAssertNoThrow(try extrator.extract())
+    }
+
+    func testErrorWillBeThrownForWrongEncodedFile() throws {
+        // Arrange
+
+        let rootPath = "/file/path"
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = true
+        fileProvider.files[rootPath] = SpecFilesDeclaration.withOneFileRef
+        fileProvider.files["/file/models.yaml"] = Data([0,1,2,3,4,5,6])
+
+        let extrator = try ReferenceExtractor(pathToSpec: URL(string: rootPath)!, fileProvider: fileProvider)
+
+        // Act
+
+        XCTAssertThrowsError(try extrator.extract())
+    }
+}

--- a/Tests/RefereceExtractorTests/FileProviderStub.swift
+++ b/Tests/RefereceExtractorTests/FileProviderStub.swift
@@ -1,0 +1,27 @@
+//
+//  FileProviderStub.swift
+//  
+//
+//  Created by Александр Кравченков on 12.12.2020.
+//
+
+import Foundation
+import ReferenceExtractor
+
+class FileProviderStub: FileProvider {
+
+    var isReadableFile: Bool = false
+
+    var files: [String: Data] = [:]
+
+    var readCount = 0
+
+    func isReadableFile(at path: String) -> Bool {
+        return isReadableFile
+    }
+
+    func readFile(at path: String) throws -> Data? {
+        readCount += 1
+        return files[path]
+    }
+}

--- a/Tests/RefereceExtractorTests/LogicTests.swift
+++ b/Tests/RefereceExtractorTests/LogicTests.swift
@@ -1,0 +1,134 @@
+//
+//  TestLogic.swift
+//  
+//
+//  Created by Александр Кравченков on 12.12.2020.
+//
+
+@testable import ReferenceExtractor
+import XCTest
+
+/// Cases:
+///
+/// - For spec without $ref no one file will be readed
+/// - For spec with local $ref no one file will be readed
+/// - For spec with 1-depth $ref only one file will be readed
+/// - For spec with 1-depth same $refs only one file will be readed
+/// - For spec with 1-depth different $refs same files will be readed
+class LogicTests: XCTestCase {
+
+    func testForSpecWithoutRefNoOneFileWillBeReaded() throws {
+        // Arrange
+
+        let rootPath = "/file/path"
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = true
+        fileProvider.files[rootPath] = SpecFilesDeclaration.withoutRefs
+
+        let extrator = try ReferenceExtractor(pathToSpec: URL(string: rootPath)!, fileProvider: fileProvider)
+
+        // Act
+
+        let refs = try extrator.extract()
+
+        // Assert
+
+        // one because we read root spec
+        XCTAssertEqual(fileProvider.readCount, 1)
+        XCTAssertTrue(refs.isEmpty, "\(refs)")
+    }
+
+    func testForSpecWithLocalRefNoOneFileWillBeReaded() throws {
+        // Arrange
+
+        let rootPath = "/file/path"
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = true
+        fileProvider.files[rootPath] = SpecFilesDeclaration.withLocalRef
+
+        let extrator = try ReferenceExtractor(pathToSpec: URL(string: rootPath)!, fileProvider: fileProvider)
+
+        // Act
+
+        let refs = try extrator.extract()
+
+        // Assert
+
+        // one because we read root spec
+        XCTAssertEqual(fileProvider.readCount, 1)
+        XCTAssertTrue(refs.isEmpty, "\(refs)")
+    }
+
+    func testForSpecWithOneDepthRefOnlyOneFileWillBeReaded() throws {
+        // Arrange
+
+        let rootPath = "/file/path"
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = true
+        fileProvider.files[rootPath] = SpecFilesDeclaration.withOneFileRef
+        fileProvider.files["/file/models.yaml"] = SpecFilesDeclaration.withoutRefs
+
+        let extrator = try ReferenceExtractor(pathToSpec: URL(string: rootPath)!, fileProvider: fileProvider)
+
+        // Act
+
+        let refs = try extrator.extract()
+
+        // Assert
+
+        // one because we read root spec
+        XCTAssertEqual(fileProvider.readCount, 2)
+        XCTAssertEqual(refs.count, 1)
+    }
+
+    func testForSpecWithOneDepthSameRefOnlyOneFileWillBeReaded() throws {
+        // Arrange
+
+        let rootPath = "/file/path"
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = true
+        fileProvider.files[rootPath] = SpecFilesDeclaration.withTwoSameFileRef
+        fileProvider.files["/file/models.yaml"] = SpecFilesDeclaration.withoutRefs
+        fileProvider.files["/file/models2.yaml"] = SpecFilesDeclaration.withoutRefs
+
+        let extrator = try ReferenceExtractor(pathToSpec: URL(string: rootPath)!, fileProvider: fileProvider)
+
+        // Act
+
+        let refs = try extrator.extract()
+
+        // Assert
+
+        // one because we read root spec
+        XCTAssertEqual(fileProvider.readCount, 2)
+        XCTAssertEqual(refs.count, 1)
+    }
+
+    func testForSpecWithOneDepthDifferentRefSameFilesCountWillBeReaded() throws {
+        // Arrange
+
+        let rootPath = "/file/path"
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = true
+        fileProvider.files[rootPath] = SpecFilesDeclaration.withTwoDifferentFileRef
+        fileProvider.files["/file/models.yaml"] = SpecFilesDeclaration.withoutRefs
+        fileProvider.files["/file/models2.yaml"] = SpecFilesDeclaration.withoutRefs
+
+        let extrator = try ReferenceExtractor(pathToSpec: URL(string: rootPath)!, fileProvider: fileProvider)
+
+        // Act
+
+        let refs = try extrator.extract()
+
+        // Assert
+
+        // one because we read root spec
+        XCTAssertEqual(fileProvider.readCount, 3)
+        XCTAssertEqual(refs.count, 2)
+    }
+}

--- a/Tests/RefereceExtractorTests/LogicTests.swift
+++ b/Tests/RefereceExtractorTests/LogicTests.swift
@@ -15,6 +15,7 @@ import XCTest
 /// - For spec with 1-depth $ref only one file will be readed
 /// - For spec with 1-depth same $refs only one file will be readed
 /// - For spec with 1-depth different $refs same files will be readed
+/// - For spec with array which contains dict with refs, all refs will be extracted
 class LogicTests: XCTestCase {
 
     func testForSpecWithoutRefNoOneFileWillBeReaded() throws {
@@ -130,5 +131,28 @@ class LogicTests: XCTestCase {
         // one because we read root spec
         XCTAssertEqual(fileProvider.readCount, 3)
         XCTAssertEqual(refs.count, 2)
+    }
+
+    func testForSpecWithArrayWhichContainsDictWithRefsAllRefsWillBeExtracted() throws {
+        // Arrange
+
+        let rootPath = "/file/path"
+
+        let fileProvider = FileProviderStub()
+        fileProvider.isReadableFile = true
+        fileProvider.files[rootPath] = SpecFilesDeclaration.withArrayWithRefs
+        fileProvider.files["/file/models.yaml"] = SpecFilesDeclaration.withoutRefs
+
+        let extrator = try ReferenceExtractor(pathToSpec: URL(string: rootPath)!, fileProvider: fileProvider)
+
+        // Act
+
+        let refs = try extrator.extract()
+
+        // Assert
+
+        // one because we read root spec
+        XCTAssertEqual(fileProvider.readCount, 2)
+        XCTAssertEqual(refs.count, 1)
     }
 }

--- a/Tests/RefereceExtractorTests/SpecFilesDeclaration.swift
+++ b/Tests/RefereceExtractorTests/SpecFilesDeclaration.swift
@@ -1,0 +1,89 @@
+//
+//  File.swift
+//  
+//
+//  Created by Александр Кравченков on 12.12.2020.
+//
+
+import Foundation
+
+struct SpecFilesDeclaration {
+    static var withOneFileRef = """
+      responses:
+        "200":
+          description: "ok"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "models.yaml#/components/schemas/CatalogItem"
+""".data(using: .utf8)!
+
+    static var withoutRefs = """
+    /billings/tariffs?serviceId={serviceId}:
+        get:
+          parameters:
+            - name: serviceId
+              required: true
+              in: query
+              schema:
+                type: string
+    """.data(using: .utf8)!
+
+    static var withLocalRef = """
+      responses:
+        "200":
+          description: "ok"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "/components/schemas/CatalogItem"
+""".data(using: .utf8)!
+
+    static var withTwoSameFileRef = """
+      responses:
+        "200":
+          description: "ok"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "models.yaml#/components/schemas/CatalogItem"
+      responses:
+        "200":
+          description: "ok"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "models.yaml#/components/schemas/CatalogItem"
+
+""".data(using: .utf8)!
+
+    static var withTwoDifferentFileRef = """
+      responses:
+        "200":
+          description: "ok"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "models.yaml#/components/schemas/CatalogItem"
+      responsesvar:
+        "200":
+          description: "ok"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "models2.yaml#/components/schemas/CatalogItem"
+
+""".data(using: .utf8)!
+}

--- a/Tests/RefereceExtractorTests/SpecFilesDeclaration.swift
+++ b/Tests/RefereceExtractorTests/SpecFilesDeclaration.swift
@@ -86,4 +86,12 @@ struct SpecFilesDeclaration {
                   $ref: "models2.yaml#/components/schemas/CatalogItem"
 
 """.data(using: .utf8)!
+
+    static var withArrayWithRefs = """
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "models.yaml#/components/schemas/AuthRequest"
+                - $ref: "models.yaml#/components/schemas/SilentAuthRequest"
+""".data(using: .utf8)!
 }


### PR DESCRIPTION
**Что сделано**:
- Добавлена сущность которая может извлекать все ссылки из YAML спеки
- Добавлены тесты на эту сущность

**Зачем**
Принцип работы всей системы такой:
1. Читаем файл из которого нужно сгенерить
2. Рекурсивно вычитываем все его зависимости (файлы на которые он ссылается через $ref)
3. Строим дерево по каждому этому файлу (зависимости остаются в узлах)
4. Во время генерации когда доходим до узла со ссылкой (которая выглядит так: `/path/to/file#/path/to/entity`)
5. Сплитим ссылку по `#` и находим дерево которое соответствует файлу по пути слева
6. Находим в дереве сущность по пути справа
7. Профит