### PR TITLE
Add cutting operation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -20,15 +20,6 @@
         }
       },
       {
-        "package": "Rainbow",
-        "repositoryURL": "https://github.com/onevcat/Rainbow",
-        "state": {
-          "branch": null,
-          "revision": "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
-          "version": "3.2.0"
-        }
-      },
-      {
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,10 @@ var testTargets: [Target] = [
     .testTarget(
         name: "CodeGeneratorTests",
         dependencies: ["Pipelines", "CodeGenerator", "Common", "ReferenceExtractor", "GASTBuilder", "UtilsForTesting"]
+    ),
+    .testTarget(
+        name: "OperationsTests",
+        dependencies: ["Operations"]
     )
 ]
 
@@ -55,6 +59,10 @@ let package = Package(
         .library(
             name: "UtilsForTesting",
             targets: ["UtilsForTesting"]
+        ),
+        .library(
+            name: "Operations",
+            targets: ["Operations"]
         ),
 
         // MARK: -- Specific
@@ -106,6 +114,7 @@ let package = Package(
                 "GASTBuilder",
                 "GASTTree",
                 "CodeGenerator",
+                "Operations"
             ],
             exclude: ["main.swift", "CLI"]
         ),
@@ -149,6 +158,9 @@ let package = Package(
             dependencies: [
                 "Common"
             ]
+        ),
+        .target(
+            name: "Operations"
         )
     ] + testTargets
 )

--- a/Sources/AnalyticsClient/LogstashClient/LogstashHttpClient.swift
+++ b/Sources/AnalyticsClient/LogstashClient/LogstashHttpClient.swift
@@ -55,9 +55,9 @@ extension LogstashHttpClient: AnalyticsClient {
 
         let task = URLSession.shared.dataTask(with: urlRequest) { _, response, error in
 
-           resp = response as! HTTPURLResponse
-
-           err = error
+//           resp = response as! HTTPURLResponse
+//
+//           err = error
 
             wg.leave()
         }

--- a/Sources/CodeGenerator/Models/PathModel.swift
+++ b/Sources/CodeGenerator/Models/PathModel.swift
@@ -78,8 +78,8 @@ public struct PathModel: Encodable {
     /// URI template
     public let path: String
     public let operations: [OperationModel]
-
-    let name: String
+    // TODO - create new model for code gen
+    public var name: String
     let pathWithSeparatedParameters: String
     let parameters: [ParameterModel]
 

--- a/Sources/Operations/PrefixCutter.swift
+++ b/Sources/Operations/PrefixCutter.swift
@@ -1,0 +1,31 @@
+//
+//  PrefixCutter.swift
+//  
+//
+//  Created by Александр Кравченков on 20.08.2021.
+//
+
+import Foundation
+
+public struct PrefixCutter {
+    let prefixesToCut: Set<String>
+}
+
+extension PrefixCutter {
+
+    public func Run(urlToCut: String) -> String? {
+        for item in self.prefixesToCut {
+
+            guard
+                let range = urlToCut.range(of: item),
+                range.lowerBound == urlToCut.startIndex
+            else {
+                continue
+            }
+
+            return String(urlToCut[range.upperBound...])
+        }
+
+        return nil
+    }
+}

--- a/Sources/Operations/PrefixCutter.swift
+++ b/Sources/Operations/PrefixCutter.swift
@@ -9,6 +9,10 @@ import Foundation
 
 public struct PrefixCutter {
     let prefixesToCut: Set<String>
+
+    public init(prefixesToCut: Set<String>) {
+        self.prefixesToCut = prefixesToCut
+    }
 }
 
 extension PrefixCutter {

--- a/Sources/Operations/README.md
+++ b/Sources/Operations/README.md
@@ -1,0 +1,3 @@
+# Operations
+
+Contains classes for different operations with API spec

--- a/Sources/Pipelines/BuldGASTTree/BuildCodeGeneratorPipelineFactory.swift
+++ b/Sources/Pipelines/BuldGASTTree/BuildCodeGeneratorPipelineFactory.swift
@@ -10,6 +10,7 @@ import Common
 import ReferenceExtractor
 import GASTBuilder
 import CodeGenerator
+import Operations
 
 /// Configures pipeline for code generator
 public struct BuildCodeGeneratorPipelineFactory {
@@ -24,7 +25,8 @@ public struct BuildCodeGeneratorPipelineFactory {
     public static func build(templates: [Template],
                              serviceName: String,
                              needRewriteExistingFiles: Bool = false,
-                             logger: Loger? = nil) -> BuildGASTTreeEntryPoint {
+                             logger: Loger? = nil,
+                             prefixCutter: PrefixCutter? = nil) -> BuildGASTTreeEntryPoint {
         let schemaBuilder = AnySchemaBuilder()
         let parameterBuilder = AnyParametersBuilder(schemaBuilder: schemaBuilder)
         let mediaTypesBuilder = AnyMediaTypesBuilder(schemaBuilder: schemaBuilder)
@@ -63,7 +65,8 @@ public struct BuildCodeGeneratorPipelineFactory {
                                 templates: templates,
                                 serviceName: serviceName,
                                 templateFiller: templateFiller,
-                                modelExtractor: modelExtractor
+                                modelExtractor: modelExtractor,
+                                prefixCutter: prefixCutter
                             ).erase()
                         ).erase(),
                         parser: buildParser()

--- a/Sources/Pipelines/CLI/Generation/GenerationCommand.swift
+++ b/Sources/Pipelines/CLI/Generation/GenerationCommand.swift
@@ -11,6 +11,7 @@ import Yams
 import Common
 import Pipelines
 import AnalyticsClient
+import Operations
 
 public class GenerationCommand: Command {
 
@@ -48,10 +49,17 @@ public class GenerationCommand: Command {
             exit(-1)
         }
 
+        var prefixCutter: PrefixCutter?
+
+        if let masks = config.prefixesToCutDownInServiceNames, !masks.isEmpty {
+            prefixCutter = PrefixCutter(masks)
+        }
+
         let pipeline = BuildCodeGeneratorPipelineFactory.build(templates: config.templates,
                                                                serviceName: serviceName,
                                                                needRewriteExistingFiles: rewrite.value,
-                                                               logger: self.loger)
+                                                               logger: self.loger,
+                                                               prefixCutter: prefixCutter)
 
         guard let specUrl = URL(string: specPath.value) else {
             self.loger.fatal("Invalid path to root spec: \(specPath.value)")

--- a/Sources/Pipelines/CLI/Generation/GenerationCommand.swift
+++ b/Sources/Pipelines/CLI/Generation/GenerationCommand.swift
@@ -52,7 +52,7 @@ public class GenerationCommand: Command {
         var prefixCutter: PrefixCutter?
 
         if let masks = config.prefixesToCutDownInServiceNames, !masks.isEmpty {
-            prefixCutter = PrefixCutter(masks)
+            prefixCutter = PrefixCutter(prefixesToCut: Set(masks))
         }
 
         let pipeline = BuildCodeGeneratorPipelineFactory.build(templates: config.templates,

--- a/Sources/Pipelines/CLI/Generation/GenerationConfig.swift
+++ b/Sources/Pipelines/CLI/Generation/GenerationConfig.swift
@@ -11,6 +11,7 @@ import CodeGenerator
 public struct AnalytcsConfig: Decodable {
     public var logstashEnpointURI: String
     public var payload: [String: String]?
+    public var prefixesToCutDownInServiceNames: [String]?
 }
 
 public struct GenerationConfig: Decodable {

--- a/Sources/Pipelines/CLI/Generation/GenerationConfig.swift
+++ b/Sources/Pipelines/CLI/Generation/GenerationConfig.swift
@@ -11,11 +11,11 @@ import CodeGenerator
 public struct AnalytcsConfig: Decodable {
     public var logstashEnpointURI: String
     public var payload: [String: String]?
-    public var prefixesToCutDownInServiceNames: [String]?
 }
 
 public struct GenerationConfig: Decodable {
 
-    var templates: [Template]
-    var analytcsConfig: AnalytcsConfig?
+    public var templates: [Template]
+    public var analytcsConfig: AnalytcsConfig?
+    public var prefixesToCutDownInServiceNames: [String]?
 }

--- a/Tests/Common/ProjectA/auth/api.yaml
+++ b/Tests/Common/ProjectA/auth/api.yaml
@@ -8,7 +8,7 @@ info:
 
 paths:
 
-  /auth:
+  /api/v1.1/auth:
     post:
       summary: Метод для отправки логина и пароля на сервер. Первый фактор авторизации.
       requestBody:

--- a/Tests/OperationsTests/PrefixCutterTests.swift
+++ b/Tests/OperationsTests/PrefixCutterTests.swift
@@ -1,0 +1,93 @@
+//
+//  PrefixCutterTests.swift
+//  
+//
+//  Created by Александр Кравченков on 20.08.2021.
+//
+
+import Foundation
+import XCTest
+@testable import Operations
+
+
+// Cases:
+//
+// 1. Check that cutting work
+// 2. Check that cutter with 2 strings will apply only 1 cut operation
+// 3. Check that cutter wont apply operation if strings don't match
+// 4. Check that cutter wont apply operation if mask is not in prefix but in secod part of url
+
+public class PrefixCutterTests: XCTestCase {
+
+    func testCuttingWorks() {
+        // Arrange
+
+        let cuttingMask = "/api"
+        let url = "/api/test"
+        let expectedUrl = "/test"
+
+        let cutter = PrefixCutter(prefixesToCut: [cuttingMask])
+
+        // Act
+
+        let newUrl = cutter.Run(urlToCut: url)
+
+        // Assert
+
+        XCTAssertEqual(newUrl, expectedUrl)
+    }
+
+    func testCutterWithTwoStringsWillApplyOnlyOneOperation() {
+        // Arrange
+
+        let cuttingMasks = Set(["/api", "/test"])
+        let url = "/api/test"
+        let expectedUrl = "/test"
+
+        let cutter = PrefixCutter(prefixesToCut: cuttingMasks)
+
+        // Act
+
+        let newUrl = cutter.Run(urlToCut: url)
+
+        // Assert
+
+        XCTAssertEqual(newUrl, expectedUrl)
+    }
+
+    func testCutterWontApplyOperationIfStringsDoNotMacth() {
+        // Arrange
+
+        let cuttingMasks = Set(["/someurl"])
+        let url = "/api/test"
+
+        let cutter = PrefixCutter(prefixesToCut: cuttingMasks)
+
+        // Act
+
+        let newUrl = cutter.Run(urlToCut: url)
+
+        // Assert
+
+        XCTAssertNil(newUrl)
+    }
+
+    // 4. Check that cutter wont apply operation if mask is not in prefix but in secod part of url
+
+    func testCutterWontApplyOperationIfMaskIsNotInPrefixButInSecondPart() {
+        // Arrange
+
+        let cuttingMasks = Set(["/test"])
+        let url = "/api/test"
+
+        let cutter = PrefixCutter(prefixesToCut: cuttingMasks)
+
+        // Act
+
+        let newUrl = cutter.Run(urlToCut: url)
+
+        // Assert
+
+        XCTAssertNil(newUrl)
+    }
+}

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -21,3 +21,6 @@ analytcsConfig:
     logstashEnpointURI: http://127.0.0.1:6644
     payload:
         project: Test
+
+prefixesToCutDownInServiceNames:
+  - /api/v1.1

--- a/trash/Sources/Models/AuthRequest/AuthRequestEntity.swift
+++ b/trash/Sources/Models/AuthRequest/AuthRequestEntity.swift
@@ -1,0 +1,56 @@
+
+import NodeKit
+
+/// Содержит все данные, необходимые для авторизации по логину и паролю
+public struct AuthRequestEntity {
+
+    // MARK: - Public Properties
+
+    /// Передается, только если есть капча Содержит строку, которую пользователь ввел как разгадку капчи. 
+    public let captcha: CaptchaPayloadInfoEntity?
+
+    public let grantType: AuthGrantType?
+
+    public let password: String?
+
+    /// Значение всегда `Login`
+    public let type: RequestMetaType?
+
+    /// То, что используется как логин пользователя (телефон, номер договора, whatever)
+    public let username: String?
+
+    // MARK: - Initialization
+
+    public init(captcha: CaptchaPayloadInfoEntity?,
+                grantType: AuthGrantType?,
+                password: String?,
+                type: RequestMetaType?,
+                username: String?) {
+        self.captcha = captcha
+        self.grantType = grantType
+        self.password = password
+        self.type = type
+        self.username = username
+    }
+
+}
+
+// MARK: - DTOConvertible
+
+extension AuthRequestEntity: DTOConvertible {
+    public static func from(dto model: AuthRequestEntry) throws -> AuthRequestEntity {
+        return try .init(captcha: .from(dto: model.captcha),
+                     grantType: model.grant_type,
+                     password: model.password,
+                     type: model.type,
+                     username: model.username)
+    }
+
+    public func toDTO() throws -> AuthRequestEntry {
+        return try .init(captcha: captcha?.toDTO(),
+                     grant_type: grantType,
+                     password: password,
+                     type: type,
+                     username: username)
+    }
+}

--- a/trash/Sources/Models/AuthResponse/AuthResponseEntity.swift
+++ b/trash/Sources/Models/AuthResponse/AuthResponseEntity.swift
@@ -1,0 +1,74 @@
+
+import NodeKit
+
+public struct AuthResponseEntity {
+
+    // MARK: - Public Properties
+
+    public let accessToken: String?
+
+    /// Дата, когда токен протухнет в ISO8601
+    public let expires: ISO8601Date?
+
+    /// если true, то необходимо запрашивать акцепт, не смотрим на isFirstEnter
+    public let isNeedAccept: Bool?
+
+    /// True если это первый вход. Тогда мы должны будем запросить оферту.
+    public let isFirstEnter: Bool?
+
+    /// Дата генерации токена в ISO8601
+    public let issued: ISO8601Date?
+
+    public let refreshToken: String?
+
+    public let tokenType: String?
+
+    public let userId: String?
+
+    // MARK: - Initialization
+
+    public init(accessToken: String?,
+                expires: ISO8601Date?,
+                isNeedAccept: Bool?,
+                isFirstEnter: Bool?,
+                issued: ISO8601Date?,
+                refreshToken: String?,
+                tokenType: String?,
+                userId: String?) {
+        self.accessToken = accessToken
+        self.expires = expires
+        self.isNeedAccept = isNeedAccept
+        self.isFirstEnter = isFirstEnter
+        self.issued = issued
+        self.refreshToken = refreshToken
+        self.tokenType = tokenType
+        self.userId = userId
+    }
+
+}
+
+// MARK: - DTOConvertible
+
+extension AuthResponseEntity: DTOConvertible {
+    public static func from(dto model: AuthResponseEntry) throws -> AuthResponseEntity {
+        return .init(accessToken: model.access_token,
+                     expires: model.expires,
+                     isNeedAccept: model.isNeedAccept,
+                     isFirstEnter: model.is_first_enter,
+                     issued: model.issued,
+                     refreshToken: model.refresh_token,
+                     tokenType: model.token_type,
+                     userId: model.user_id)
+    }
+
+    public func toDTO() throws -> AuthResponseEntry {
+        return .init(access_token: accessToken,
+                     expires: expires,
+                     isNeedAccept: isNeedAccept,
+                     is_first_enter: isFirstEnter,
+                     issued: issued,
+                     refresh_token: refreshToken,
+                     token_type: tokenType,
+                     user_id: userId)
+    }
+}

--- a/trash/Sources/Models/CaptchaPayloadInfo/CaptchaPayloadInfoEntity.swift
+++ b/trash/Sources/Models/CaptchaPayloadInfo/CaptchaPayloadInfoEntity.swift
@@ -1,0 +1,37 @@
+
+import NodeKit
+
+/// Объект содержит информацию, которая позволяет однозначно установить верно ли была распознана капча или нет.
+public struct CaptchaPayloadInfoEntity {
+
+    // MARK: - Public Properties
+
+    /// Тот же хэш, который приходит в `Captcha`
+    public let hash: String?
+
+    /// Значение, которое ввел пользователь (распознанное значение)
+    public let value: String?
+
+    // MARK: - Initialization
+
+    public init(hash: String?,
+                value: String?) {
+        self.hash = hash
+        self.value = value
+    }
+
+}
+
+// MARK: - DTOConvertible
+
+extension CaptchaPayloadInfoEntity: DTOConvertible {
+    public static func from(dto model: CaptchaPayloadInfoEntry) throws -> CaptchaPayloadInfoEntity {
+        return .init(hash: model.hash,
+                     value: model.value)
+    }
+
+    public func toDTO() throws -> CaptchaPayloadInfoEntry {
+        return .init(hash: hash,
+                     value: value)
+    }
+}

--- a/trash/Sources/Models/CommonError/CommonErrorEntity.swift
+++ b/trash/Sources/Models/CommonError/CommonErrorEntity.swift
@@ -1,0 +1,44 @@
+
+import NodeKit
+
+/// Это общий тип ошибки, который может возвращать сервер.
+public struct CommonErrorEntity {
+
+    // MARK: - Public Properties
+
+    /// Это идентификатор ошибки. Этот идентификатор мобильное приложение будет использовать для того, чтобы включать определенное поведение.
+    public let code: Int
+
+    /// Пояснение для разработчика/тестировщика о том, что пошло не так
+    public let developerMessage: String?
+
+    /// Сообщение, которое будет выведено пользователю в снеке в случае получения ошибки
+    public let userMessage: String?
+
+    // MARK: - Initialization
+
+    public init(code: Int,
+                developerMessage: String?,
+                userMessage: String?) {
+        self.code = code
+        self.developerMessage = developerMessage
+        self.userMessage = userMessage
+    }
+
+}
+
+// MARK: - DTOConvertible
+
+extension CommonErrorEntity: DTOConvertible {
+    public static func from(dto model: CommonErrorEntry) throws -> CommonErrorEntity {
+        return .init(code: model.code,
+                     developerMessage: model.developerMessage,
+                     userMessage: model.userMessage)
+    }
+
+    public func toDTO() throws -> CommonErrorEntry {
+        return .init(code: code,
+                     developerMessage: developerMessage,
+                     userMessage: userMessage)
+    }
+}

--- a/trash/Sources/Models/SilentAuthRequest/SilentAuthRequestEntity.swift
+++ b/trash/Sources/Models/SilentAuthRequest/SilentAuthRequestEntity.swift
@@ -1,0 +1,35 @@
+
+import NodeKit
+
+/// Запрос для обновления AccessToken-а
+public struct SilentAuthRequestEntity {
+
+    // MARK: - Public Properties
+
+    public let grantType: AuthGrantType?
+
+    public let refreshToken: String?
+
+    // MARK: - Initialization
+
+    public init(grantType: AuthGrantType?,
+                refreshToken: String?) {
+        self.grantType = grantType
+        self.refreshToken = refreshToken
+    }
+
+}
+
+// MARK: - DTOConvertible
+
+extension SilentAuthRequestEntity: DTOConvertible {
+    public static func from(dto model: SilentAuthRequestEntry) throws -> SilentAuthRequestEntity {
+        return .init(grantType: model.grant_type,
+                     refreshToken: model.refresh_token)
+    }
+
+    public func toDTO() throws -> SilentAuthRequestEntry {
+        return .init(grant_type: grantType,
+                     refresh_token: refreshToken)
+    }
+}

--- a/trash/Sources/Models/auth_grant_type/auth_grant_type.swift
+++ b/trash/Sources/Models/auth_grant_type/auth_grant_type.swift
@@ -1,0 +1,25 @@
+
+import NodeKit
+
+public struct Entity {
+
+    // MARK: - Public Properties
+
+    // MARK: - Initialization
+
+    public init(
+    }
+
+}
+
+// MARK: - DTOConvertible
+
+extension Entity: DTOConvertible {
+    public static func from(dto model: Entry) throws -> Entity {
+        return .init()
+    }
+
+    public func toDTO() throws -> Entry {
+        return .init()
+    }
+}

--- a/trash/Sources/Models/request_meta_type/request_meta_type.swift
+++ b/trash/Sources/Models/request_meta_type/request_meta_type.swift
@@ -1,0 +1,25 @@
+
+import NodeKit
+
+public struct Entity {
+
+    // MARK: - Public Properties
+
+    // MARK: - Initialization
+
+    public init(
+    }
+
+}
+
+// MARK: - DTOConvertible
+
+extension Entity: DTOConvertible {
+    public static func from(dto model: Entry) throws -> Entity {
+        return .init()
+    }
+
+    public func toDTO() throws -> Entry {
+        return .init()
+    }
+}

--- a/trash/Sources/Services/Auth/AuthService.swift
+++ b/trash/Sources/Services/Auth/AuthService.swift
@@ -1,0 +1,15 @@
+//
+//  AuthService.swift
+//
+
+import NodeKit
+
+public protocol AuthService {
+
+    /// Метод для отправки логина и пароля на сервер. Первый фактор авторизации.
+    func postAuth(authRequest: AuthRequest?) -> Observer<AuthResponseEntity>
+
+    /// Метод для отправки логина и пароля на сервер. Первый фактор авторизации.
+    func postAuth(silentAuthRequest: SilentAuthRequest?) -> Observer<AuthResponseEntity>
+
+}


### PR DESCRIPTION
Added PrefixCutter to cut URL prefixes (for example for creating services names)

Lets imagine that we have this url `/api/v1.1/auth` if we convert it to name without cutting we will have 
```Swift
func apiv1.1Auth()
```

And it's obvious that this code won't be compiled

So now you can add to your generation config:

```yaml
prefixesToCutDownInServiceNames:
  - /api/v1.1
```

And everything will go well