### PR TITLE
Handling path parameters declaration place

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -90,6 +90,15 @@
           "revision": "2e949055d9797c1a6bddcda0e58dada16cc8e970",
           "version": "6.0.3"
         }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams",
+        "state": {
+          "branch": null,
+          "revision": "b08dba4bcea978bf1ad37703a384097d3efce5af",
+          "version": "1.0.2"
+        }
       }
     ]
   },

--- a/Sources/CodeGenerator/Models/GenerationModels/PathGenerationModel.swift
+++ b/Sources/CodeGenerator/Models/GenerationModels/PathGenerationModel.swift
@@ -25,7 +25,7 @@ public struct PathGenerationModel: Encodable {
             .map { OperationGenerationModel(operationModel: $0) }
         self.name = pathModel.path.pathName
         self.pathWithSeparatedParameters = pathModel.path.pathWithSeparatedParameters
-        self.parameters = operations[0].pathParameters
+        self.parameters = pathModel.parameters.map { $0.value }
     }
 
 }

--- a/Sources/CodeGenerator/Models/PathModel.swift
+++ b/Sources/CodeGenerator/Models/PathModel.swift
@@ -41,10 +41,12 @@ import Foundation
 public struct PathModel: Encodable {
     /// URI template
     public let path: String
+    public let parameters: [Reference<ParameterModel>]
     public let operations: [OperationModel]
 
-    public init(path: String, operations: [OperationModel]) {
+    public init(path: String, parameters: [Reference<ParameterModel>], operations: [OperationModel]) {
         self.path = path
+        self.parameters = parameters
         self.operations = operations.sorted { $0.httpMethod < $1.httpMethod }
     }
     

--- a/Sources/CodeGenerator/Stages/TreeParserStage/TreeParser/TreeParser.swift
+++ b/Sources/CodeGenerator/Stages/TreeParserStage/TreeParser/TreeParser.swift
@@ -59,9 +59,12 @@ public struct TreeParser {
             )
         }
 
+        let parameters = try service.parameters.map {
+            try parametersParser.parse(parameter: $0, current: current, other: other)
+        }
         let operations = try service.operations.map(mapper)
 
-        return .init(path: service.path, operations: operations)
+        return .init(path: service.path, parameters: parameters, operations: operations)
     }
 
     func parse(operation: OperationNode, current: DependencyWithTree, other: [DependencyWithTree]) throws -> OperationModel {

--- a/Sources/GASTTree/Services/PathNode.swift
+++ b/Sources/GASTTree/Services/PathNode.swift
@@ -9,10 +9,12 @@ import Foundation
 
 public struct PathNode {
     public var path: String
+    public let parameters: [Referenced<ParameterNode>]
     public var operations: [OperationNode]
 
-    public init(path: String, operations: [OperationNode]) {
+    public init(path: String, parameters: [Referenced<ParameterNode>], operations: [OperationNode]) {
         self.path = path
+        self.parameters = parameters
         self.operations = operations
     }
 }

--- a/Sources/Pipelines/CodeGen/SwaggerCorrectorStage.swift
+++ b/Sources/Pipelines/CodeGen/SwaggerCorrectorStage.swift
@@ -25,9 +25,10 @@ class SwaggerCorrectorStage: PipelineStage {
     }
 
     private func correctService(_ service: [PathModel]) -> [PathModel] {
-        return service.map { path in
-            return PathModel(path: corrector.correctPath(path.path),
-                             operations: path.operations)
+        return service.map { pathModel in
+            return PathModel(path: corrector.correctPath(pathModel.path),
+                             parameters: corrector.correctPathParameters(for: pathModel),
+                             operations: pathModel.operations)
         }
     }
 }

--- a/Tests/CodeGeneratorTests/SwaggerCorrectorYamls.swift
+++ b/Tests/CodeGeneratorTests/SwaggerCorrectorYamls.swift
@@ -1,0 +1,32 @@
+//
+//  SwaggerCorrectorYamls.swift
+//  
+//
+//  Created by Дмитрий Демьянов on 08.11.2021.
+//
+
+import Foundation
+
+enum SwaggerCorrectorYamls {
+    /// Contains service `messages` with one operation `get`
+    /// Service has path parameter `id` with type `string`, it is declared in `Operation`
+    static var yamlWithPathParametersInOperationWontBeParsed = """
+    paths:
+      /messages/{id}:
+        get:
+          parameters:
+            - name: id
+              required: true
+              in: path
+              schema:
+                type: string
+          responses:
+            default:
+                description: "Все ок"
+                content:
+                    application/json:
+                        schema:
+                            type: integer
+
+""".data(using: .utf8)!
+}

--- a/Tests/PipelinesTests/YamlToGenerationModelsTests/Yamls.swift
+++ b/Tests/PipelinesTests/YamlToGenerationModelsTests/Yamls.swift
@@ -8,6 +8,51 @@
 import Foundation
 
 extension ParametersTests {
+
+    /// Contains service `messages` with one operation `get`
+    /// Service has path parameter `id` with type `string`, it is declared in `Path`
+    static var yamlWithPathParametersInPathWillBeParsed = """
+    paths:
+      /messages/{id}:
+        parameters:
+          - name: id
+            required: true
+            in: path
+            schema:
+              type: string
+        get:
+          responses:
+            default:
+                description: "Все ок"
+                content:
+                    application/json:
+                        schema:
+                            type: integer
+
+""".data(using: .utf8)!
+
+    /// Contains service `messages` with one operation `get`
+    /// Service has path parameter `id` with type `string`, it is declared in `Operation`
+    static var yamlWithPathParametersInOperationWontBeParsed = """
+    paths:
+      /messages/{id}:
+        get:
+          parameters:
+            - name: id
+              required: true
+              in: path
+              schema:
+                type: string
+          responses:
+            default:
+                description: "Все ок"
+                content:
+                    application/json:
+                        schema:
+                            type: integer
+
+""".data(using: .utf8)!
+
     /// Contains service `messages` with one operation `get`
     /// And the operation contains two parameters `id2` and `id3` with `integer` and `string` types
     /// Each parameter is declared `in place`


### PR DESCRIPTION
### Done:
- taking path parameters from `Path` object instead of `Operation`
- giving warning if path parameters are declared in `Operation`

### Details:
First, let's compare two specs.

1:
```yaml
paths:
      /messages/{id}:
        parameters:
          - name: id
            required: true
            in: path
            schema:
              type: string
        get:
          responses:
            default:
                description: "Все ок"
                content:
                    application/json:
                        schema:
                            type: integer
```
2:
```yaml
paths:
      /messages/{id}:
        get:
          parameters:
            - name: id
              required: true
              in: path
              schema:
                type: string
          responses:
            default:
                description: "Все ок"
                content:
                    application/json:
                        schema:
                            type: integer
```

In spec 1 path parameter `id` is declared inside path object and this it how it should be.

In spec 2 path the parameter is declared inside operation. Previously we didn't take attention on this, but this declaration is a potential problem. If there are more then one operations for one path, the parameter should be duplicated for each operation. So now we give warning if path parameters are declared in `Operation`, like in spec 2.